### PR TITLE
Added setters for manual QueryParameters contruction in GraphQL extension

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/rest/beans/QueryFilter.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/beans/QueryFilter.java
@@ -102,6 +102,10 @@ public class QueryFilter implements Serializable {
         return values;
     }
 
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
     public Date getDateValue() {
         return dateValue;
     }

--- a/core/src/main/java/com/kumuluz/ee/rest/beans/QueryFilter.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/beans/QueryFilter.java
@@ -102,10 +102,6 @@ public class QueryFilter implements Serializable {
         return values;
     }
 
-    public void setValues(List<String> values) {
-        this.values = values;
-    }
-
     public Date getDateValue() {
         return dateValue;
     }

--- a/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
@@ -73,6 +73,10 @@ public class QueryParameters implements Serializable {
         this.filters = filters;
     }
 
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
     public List<QueryOrder> getOrder() {
 
         if (order == null)

--- a/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
@@ -65,6 +65,14 @@ public class QueryParameters implements Serializable {
         this.offset = offset.longValue();
     }
 
+    public void setOrder(List<QueryOrder> order) {
+        this.order = order;
+    }
+
+    public void setFilters(List<QueryFilter> filters) {
+        this.filters = filters;
+    }
+
     public List<QueryOrder> getOrder() {
 
         if (order == null)


### PR DESCRIPTION
Setters are needed when constructing QueryParameters object from GraphQL extension's Pagination, Sort and Filter objects.