### PR TITLE
Allow traversing toMany relationships for order queries

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/rest/utils/JPAUtils.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/utils/JPAUtils.java
@@ -330,12 +330,6 @@ public class JPAUtils {
 
                 if (null != field) {
 
-                    if (field.containsToMany()) {
-                        throw new InvalidEntityFieldException(
-                                "OneToMany and ManyToMany relations are not supported by the order query",
-                                qo.getField(), r.getJavaType().getSimpleName());
-                    }
-
                     if (qo.getOrder() == OrderDirection.DESC) {
 
                         orders.add(cb.desc(field.getPath()));


### PR DESCRIPTION
JPA allow traversing toMany relationships.
Is this check obsolete and can be removed ?
Is there a bigger problem I didn't see ? In this case I would be glad to help.