### PR TITLE
added count parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ Long allCustomersCount = JPAUtils.queryEntitiesCount(em, Customer.class, query);
 
 return Response.ok(allCustomers).header("X-Total-Count", allCustomersCount).build();
 ```
+
+With very large datasets counting all filtered records can be very slow. That is why it's possible to specify the `count` parameter, which can than be used to decide whether or not to perform the count.
+
+```
+GET /v1/customers?offset=10
+GET /v1/customers?count=true&limit=5
+GET /v1/customers?count=false&offset=10&limit=5
+```
+
+Parameter `count` is set to `true`by default.
+
+__NOTE__: When using `JpaUtils.getQueried` counting is performed (or not performed) automatically, depending on the value of `count`.
+
 #### Sorting
 
 Sorting of entities can be specified by providing the field and direction.

--- a/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/beans/QueryParameters.java
@@ -34,6 +34,8 @@ public class QueryParameters implements Serializable {
 
     private final static long serialVersionUID = 1L;
 
+    private Boolean count;
+
     private Long limit;
     private Long offset;
 
@@ -41,6 +43,18 @@ public class QueryParameters implements Serializable {
     private List<String> fields;
     private List<QueryFilter> filters;
     private QueryFilterExpression filterExpression;
+
+    public boolean getCount() {
+        if (count == null) {
+            return true;
+        }
+
+        return count;
+    }
+
+    public void setCount(Boolean count) {
+        this.count = count;
+    }
 
     public Long getLimit() {
         return limit;

--- a/core/src/main/java/com/kumuluz/ee/rest/enums/QueryFormatError.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/enums/QueryFormatError.java
@@ -25,5 +25,9 @@ package com.kumuluz.ee.rest.enums;
  */
 public enum QueryFormatError {
 
-    MALFORMED, NOT_A_NUMBER, NEGATIVE, NO_SUCH_CONSTANT
+    MALFORMED,
+    NOT_A_NUMBER,
+    NEGATIVE,
+    NO_SUCH_CONSTANT,
+    NOT_A_BOOLEAN
 }

--- a/core/src/main/java/com/kumuluz/ee/rest/utils/JPAUtils.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/utils/JPAUtils.java
@@ -145,7 +145,10 @@ public class JPAUtils {
     public static <T> Queried<T> getQueried(EntityManager em, Class<T> entity, QueryParameters q, CriteriaFilter<T> customFilter,
                                             List<QueryHintPair> queryHints, String rootAlias, boolean forceDistinct) {
 
-        Long totalCount = queryEntitiesCount(em, entity, q, customFilter);
+        Long totalCount = null;
+        if (q.getCount()) {
+            totalCount = queryEntitiesCount(em, entity, q, customFilter);
+        }
         Stream<T> entityStream = getEntityStream(em, entity, q, customFilter, queryHints, rootAlias, forceDistinct);
 
         return Queried.result(totalCount, entityStream);
@@ -231,10 +234,11 @@ public class JPAUtils {
         if (em == null || entity == null)
             throw new IllegalArgumentException("The entity manager and the entity cannot be null.");
 
-        if (q == null)
+        if (q == null) {
             throw new IllegalArgumentException("Query parameters can't be null. " +
                     "If you don't have any parameters either pass a empty object or " +
                     "use the queryEntitiesCount(EntityManager, Class<T>) method.");
+        }
 
         LOG.finest("Querying entity count: '" + entity.getSimpleName() + "' with parameters: " + q);
 

--- a/core/src/main/java/com/kumuluz/ee/rest/utils/QueryStringBuilder.java
+++ b/core/src/main/java/com/kumuluz/ee/rest/utils/QueryStringBuilder.java
@@ -51,6 +51,8 @@ public class QueryStringBuilder {
 
     private static final Logger log = Logger.getLogger(QueryStringBuilder.class.getSimpleName());
 
+    public static final String COUNT_DELIMITER = "count";
+
     public static final String LIMIT_DELIMITER = "limit";
     public static final String LIMIT_DELIMITER_ALT = "max";
 
@@ -298,6 +300,10 @@ public class QueryStringBuilder {
 
         switch (key) {
 
+            case COUNT_DELIMITER:
+                params.setCount(buildCount(key, value));
+                break;
+
             case LIMIT_DELIMITER:
             case LIMIT_DELIMITER_ALT:
 
@@ -353,6 +359,22 @@ public class QueryStringBuilder {
         }
 
         addDefaultFilters(params);
+    }
+
+    private Boolean buildCount(String key, String value) {
+        log.finest("Building count string: " + value);
+
+        if (value == null || value.equalsIgnoreCase("true")) {
+            return true;
+        } else if (value.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        String msg = "Value for '" + key + "' is not a valid boolean: '" + value + "'";
+
+        log.finest(msg);
+
+        throw new QueryFormatException(msg, key, QueryFormatError.NOT_A_BOOLEAN);
     }
 
     private Long buildOffset(String key, String value) {

--- a/core/src/test/java/com/kumuluz/ee/rest/test/QueriedTest.java
+++ b/core/src/test/java/com/kumuluz/ee/rest/test/QueriedTest.java
@@ -59,4 +59,47 @@ public class QueriedTest {
         Assert.assertEquals(limit, queried.stream().count());
     }
 
+    @Test
+    public void testQueriedWithCount() {
+        QueryParameters q = new QueryParameters();
+        q.setCount(true);
+
+        Queried<User> queried = JPAUtils.getQueried(em, User.class, q);
+
+        Assert.assertNotNull(queried);
+        Assert.assertEquals(Long.valueOf(100L), queried.getTotalCount());
+    }
+
+    @Test
+    public void testQueriedWithNoCount() {
+        QueryParameters q = new QueryParameters();
+
+        Queried<User> queried = JPAUtils.getQueried(em, User.class, q);
+
+        Assert.assertNotNull(queried);
+        Assert.assertEquals(Long.valueOf(100L), queried.getTotalCount());
+    }
+
+    @Test
+    public void testQueriedWithCountTrue() {
+        QueryParameters q = new QueryParameters();
+        q.setCount(true);
+
+        Queried<User> queried = JPAUtils.getQueried(em, User.class, q);
+
+        Assert.assertNotNull(queried);
+        Assert.assertEquals(Long.valueOf(100L), queried.getTotalCount());
+    }
+
+    @Test
+    public void testQueriedWithCountFalse() {
+        QueryParameters q = new QueryParameters();
+        q.setCount(false);
+
+        Queried<User> queried = JPAUtils.getQueried(em, User.class, q);
+
+        Assert.assertNotNull(queried);
+        Assert.assertNull(queried.getTotalCount());
+    }
+
 }

--- a/core/src/test/java/com/kumuluz/ee/rest/test/QueryStringBuilderCountTest.java
+++ b/core/src/test/java/com/kumuluz/ee/rest/test/QueryStringBuilderCountTest.java
@@ -1,0 +1,66 @@
+package com.kumuluz.ee.rest.test;
+
+import com.kumuluz.ee.rest.beans.QueryParameters;
+import com.kumuluz.ee.rest.enums.QueryFormatError;
+import com.kumuluz.ee.rest.exceptions.QueryFormatException;
+import com.kumuluz.ee.rest.utils.QueryStringDefaults;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Tilen Faganel
+ */
+public class QueryStringBuilderCountTest {
+
+    @Test
+    public void testEmpty() {
+        QueryParameters query = new QueryStringDefaults().builder().query("").build();
+
+        Assert.assertNotNull(query);
+        Assert.assertTrue(query.getCount());
+    }
+
+    @Test
+    public void testCountTrue() {
+        QueryParameters query = new QueryStringDefaults().builder().query("count=true").build();
+
+        Assert.assertNotNull(query);
+        Assert.assertTrue(query.getCount());
+    }
+
+    @Test
+    public void testCountFalse() {
+        QueryParameters query = new QueryStringDefaults().builder().query("count=false").build();
+
+        Assert.assertNotNull(query);
+        Assert.assertFalse(query.getCount());
+    }
+
+    @Test
+    public void testCountCaseInsensitiveFalse() {
+        QueryParameters query = new QueryStringDefaults().builder().query("count=FAlse").build();
+
+        Assert.assertNotNull(query);
+        Assert.assertFalse(query.getCount());
+    }
+
+    @Test
+    public void testCountMultiple() {
+        QueryParameters query = new QueryStringDefaults().builder().query("count=true&count=false").build();
+
+        Assert.assertNotNull(query);
+        Assert.assertFalse(query.getCount());
+    }
+
+    @Test
+    public void testCountMalformed() {
+        try {
+
+            new QueryStringDefaults().builder().query("count=tru").build();
+            Assert.fail("No exception was thrown");
+        } catch (QueryFormatException e) {
+            Assert.assertEquals("count", e.getField());
+            Assert.assertEquals(QueryFormatError.NOT_A_BOOLEAN, e.getReason());
+        }
+    }
+}


### PR DESCRIPTION
added count parameter, when using JpaUtils.getQueried counting is performed depending on the value of the count parameter